### PR TITLE
feat: retrieval of docs by id and pagination support

### DIFF
--- a/controllers/FilesController.js
+++ b/controllers/FilesController.js
@@ -91,4 +91,52 @@ export default class FilesController {
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   }
+
+  static async getShow(req, res) {
+    const token = req.headers['x-token'];
+    if (!token) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const userId = await redisClient.get(`auth_${token}`);
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const { id } = req.params;
+    if (!ObjectId.isValid(id)) {
+      return res.status(400).json({ error: 'Invalid ID' });
+    }
+
+    const file = await dbClient.db.collection('files')
+      .findOne({ _id: new ObjectId(id), userId: new ObjectId(userId) });
+    if (!file) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    return res.status(200).json(file);
+  }
+
+  static async getIndex(req, res) {
+    const token = req.headers['x-token'];
+    if (!token) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const userId = await redisClient.get(`auth_${token}`);
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const { parentId = 0, page = 0 } = req.query;
+
+    const pageSize = 20;
+    const paginationSkip = page * pageSize;
+
+    const files = await dbClient.db.collection('files').aggregate([
+      { $match: { parentId: parentId === '0' ? 0 : new ObjectId(parentId), userId: new ObjectId(userId) } },
+      { $skip: paginationSkip },
+      { $limit: pageSize },
+    ]).toArray();
+    return res.status(200).json(files);
+  }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -20,4 +20,7 @@ router.get('/users/me', UsersController.getMe);
 // File controller routes
 router.post('/files', FilesController.postUpload);
 
+router.get('/files/:id', FilesController.getShow);
+router.get('/files', FilesController.getIndex);
+
 export default router;


### PR DESCRIPTION
## Description
This PR introduces two new endpoints to the file management system:

1. **`GET /files/:id`** - Retrieves a specific file by ID.
2. **`GET /files`** - Retrieves a list of files with optional `parentId` and pagination.

## Changes

**1. `routes/index.js`**
- Added endpoints:
  - `GET /files/:id` -> `FilesController.getShow`
  - `GET /files` -> `FilesController.getIndex`

**2. `controllers/FilesController.js`**
- **`GET /files/:id`**: Fetches a file by ID.
  - Returns `401 Unauthorized` if token is missing or invalid.
  - Returns `404 Not Found` if the file does not belong to the user.
  - Otherwise, returns the file document.
- **`GET /files`**: Retrieves files for a user, filtered by `parentId` and paginated.
  - Returns `401 Unauthorized` if token is invalid.
  - Supports pagination with a default page size of 20 items per page.

## Implementation Details
- **Pagination**: Implemented using MongoDB’s aggregation framework.
- **Authorization**: Token-based authentication via `x-token` header.
